### PR TITLE
Supports CocoaPods

### DIFF
--- a/LINEActivity.podspec
+++ b/LINEActivity.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name         = "LINEActivity"
+  s.version      = "1.0"
+  s.summary      = "LINEActivity is an iOS 6 UIActivity subclass for LINE."
+  s.homepage     = "https://github.com/nottihub/LINEActivity"
+  s.license      = 'Apache'
+  s.author       = "nottihub"
+  s.source       = { :git => "https://github.com/nottihub/LINEActivity.git" }
+  s.platform     = :ios
+
+  s.source_files = 'LINEActivity/*.{h,m}'
+  s.resource     = 'LINEActivity/*.png'
+  s.requires_arc = true
+
+  s.ios.deployment_target = '5.0'
+  s.ios.frameworks        = [ 'Foundation', 'UIKit' ]
+end


### PR DESCRIPTION
I added file of LINEActivity.podspec.
so you will be able to use the LINEActivity in CocoaPods.

**Podfile**

```
pod  'LINEActivity', :git => 'https://github.com/nottihub/LINEActivity.git'
```
