### PR TITLE
Use generalPasteboard for iOS 7 and later

### DIFF
--- a/LINEActivity/LINEActivity.m
+++ b/LINEActivity/LINEActivity.m
@@ -62,7 +62,12 @@
         NSString *urlEncodeString = (NSString *)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes( NULL, (CFStringRef)item, NULL, (CFStringRef)@"!*'();:@&=+$,/?%#[]", kCFStringEncodingUTF8 ));
         LINEURLString = [NSString stringWithFormat:@"line://msg/text/%@", urlEncodeString];
     } else if ([item isKindOfClass:[UIImage class]]) {
-        UIPasteboard *pasteboard = [UIPasteboard pasteboardWithUniqueName];
+        UIPasteboard *pasteboard;
+        if ([[[UIDevice currentDevice] systemVersion] compare:@"7.0" options:NSNumericSearch] != NSOrderedAscending) {
+            pasteboard = [UIPasteboard generalPasteboard];
+        } else {
+            pasteboard = [UIPasteboard pasteboardWithUniqueName];
+        }
         [pasteboard setData:UIImagePNGRepresentation(item) forPasteboardType:@"public.png"];
         LINEURLString = [NSString stringWithFormat:@"line://msg/image/%@", pasteboard.name];
     } else {


### PR DESCRIPTION
Sample app is not able to share image on iOS 7. This PR would fix the issue.

As iOS 7 release note (https://developer.apple.com/library/ios/releasenotes/General/RN-iOSSDK-7.0/ ) says

> +[UIPasteboard pasteboardWithName:create:] and +[UIPasteboard pasteboardWithUniqueName] now unique the given name to allow only those apps in the same application group to access the pasteboard. If the developer attempts to create a pasteboard with a name that already exists and they are not part of the same app suite, they will get their own unique and private pasteboard. Note that this does not affect the system provided pasteboards, general, and find.
